### PR TITLE
Added launch-submit-and-destroy functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ spark-janelia submit -s <submit_arguments>
 ```
 Where `submit_arguments` is a string of arguments you would normally pass to `spark-submit`, as described in the [Spark documentation](https://spark.apache.org/docs/1.2.0/submitting-applications.html).
 
-#### Running a spark application and delete cluster job after completion
-If you want to to run an application that with unknown runtime
-it will be helpful to have the cluster job delete after completion of the application.
+#### Running a Spark application with automatic shut down of the Spark cluster after completion
+If you want to run an application with unknown runtime
+it will be helpful to have the Spark cluster shut down automatically after completion of the application.
 ```bash
 spark-janelia <args> lsd -s <submit_arguments>
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ spark-janelia submit -s <submit_arguments>
 ```
 Where `submit_arguments` is a string of arguments you would normally pass to `spark-submit`, as described in the [Spark documentation](https://spark.apache.org/docs/1.2.0/submitting-applications.html).
 
+#### Running a spark application and delete cluster job after completion
+If you want to to run an application that with unknown runtime
+it will be helpful to have the cluster job delete after completion of the application.
+```bash
+spark-janelia <args> lsd -s <submit_arguments>
+```
+will submit your application and delete the cluter job, once it has finished. `lsd` is short for `launch-submit-and-destroy` and the meaning of `submit_arguments` is along the lines of `spark-janelia submit`.
+
 ---
 ### Using Thunder
 Many of us at Janelia are using the [Thunder](http://thunder-project.com/thunder/) library for working with neural data in Spark. The scripts in this repo also make installing and using Thunder easy. 

--- a/spark-janelia
+++ b/spark-janelia
@@ -29,11 +29,11 @@ def isSparkJob(job):
     return job.find('jclass_name').text == version_short + '.default'
 
 
-def launch():
+def launch(sleepTime='86400'):
     if not os.path.exists(os.path.expanduser('~/sparklogs')):
         os.mkdir(os.path.expanduser('~/sparklogs'))
 
-    output = subprocess.check_output(['qsub', '-jc', version_short, '-pe', version_short, str(args.nnodes), '-q', 'hadoop2', '-j', 'y', '-o', os.path.expanduser('~/sparklogs/'), '/sge/8.1.4/examples/jobs/sleeper.sh', '86400'])
+    output = subprocess.check_output(['qsub', '-jc', version_short, '-pe', version_short, str(args.nnodes), '-q', 'hadoop2', '-j', 'y', '-o', os.path.expanduser('~/sparklogs/'), '/sge/8.1.4/examples/jobs/sleeper.sh', sleepTime])
     print('\n')
     print('Spark job submitted with ' + str(args.nnodes) + ' nodes')
     print('\n')

--- a/spark-janelia
+++ b/spark-janelia
@@ -7,36 +7,28 @@ import argparse
 import subprocess
 import xml.etree.ElementTree as ET
 
-parser = argparse.ArgumentParser(description="launch and manage spark cluster jobs")
 
-parser.add_argument("task", choices=('launch', 'login', 'destroy', 'start', 'start-scala', 'submit'))
-parser.add_argument("-n", "--nnodes", type=int, default=2, required=False)
-parser.add_argument("-i", "--ipython", action="store_true")
-parser.add_argument("-v", "--version", choices=("1", "2", "3"), default="1", required=False)
-parser.add_argument("-j", "--jobid", type=int, default=None, required=False)
-parser.add_argument("-s", "--submitargs", type=str, default='', required=False)
+def findMasterByJobId(jobId):
+    status = subprocess.check_output(['qstat', '-xml'])
+    master = ''
+    qtree = ET.fromstring(status)[0]
+    rjobs = qtree.findall(".//job_list[@state='running']")
+    for job in rjobs:
+        if not isSparkJob( job ):
+            continue
+        currMaster = job.find('queue_name').text.split('@')[1]
+        currJobId  = job.find('JB_job_number').text
+        if jobId == '' or currJobId == jobId:
+            master = currMaster
+            break
+    return master
 
-args = parser.parse_args()
 
-SPARKVERSIONS = {
-    '1': '/usr/local/spark-current',
-    '2': '/usr/local/spark-master',
-    '3': '/usr/local/spark-test'
-}
+def isSparkJob(job):
+    return job.find('jclass_name').text == version_short + '.default'
 
-SPARKVERSIONSSHORT = {
-    '1': 'spark',
-    '2': 'spark2',
-    '3': 'spark3'
-}
 
-version = SPARKVERSIONS[args.version]
-version_short = SPARKVERSIONSSHORT[args.version]
-
-if args.nnodes == 1:
-    raise Exception('Cannot start a Spark cluster with only 1 node, please request 2 or more.')
-
-if args.task == 'launch':
+def launch():
     if not os.path.exists(os.path.expanduser('~/sparklogs')):
         os.mkdir(os.path.expanduser('~/sparklogs'))
 
@@ -44,8 +36,12 @@ if args.task == 'launch':
     print('\n')
     print('Spark job submitted with ' + str(args.nnodes) + ' nodes')
     print('\n')
+    # Your job <jobId> ("Sleeper") has been submitted
+    jobId = output.split(' ')[2]
+    return jobId
 
-elif args.task == 'login':
+
+def login(jobId = ''):
     status = subprocess.check_output(["qstat", "-xml"])
     qtree = ET.fromstring(status)[0]
     jtree = ET.fromstring(status)[1]
@@ -77,11 +73,14 @@ elif args.task == 'login':
             print >> sys.stderr, "No Spark job found, check status with qstat, or try a different jobid?"
             print('\n')
 
-elif args.task == 'destroy':
+
+def destroy(jobId = ''):
     status = subprocess.check_output(["qstat", "-xml"])
     qtree = ET.fromstring(status)[0]
     jtree = ET.fromstring(status)[1]
     jobs = qtree.findall('job_list')
+    jid = args.jobid or jobId
+    jid = int(jid)
     if len(jobs) == 0:
         print('\n')
         print >> sys.stderr, "No running jobs found"
@@ -93,8 +92,8 @@ elif args.task == 'destroy':
             state = job.find('state').text
             jobid = job.find('JB_job_number').text
             if (jobclass == version_short + ".default") and (state == 'r'):
-                if args.jobid:
-                    if int(jobid) == args.jobid:
+                if jid:
+                    if int(jobid) == jid:
                         output = subprocess.check_output(['qdel', jobid])
                         deleted += 1
                 else:
@@ -109,8 +108,8 @@ elif args.task == 'destroy':
             print('Spark jobs successfully deleted')
             print('\n')
 
-elif args.task == 'start':
 
+def start():
     f = open(os.path.expanduser("~") + '/spark-master', 'r')
     master = f.readline().replace('\n','')
 
@@ -133,8 +132,8 @@ elif args.task == 'start':
     os.environ['MASTER'] = master
     os.system(version + '/bin/pyspark')
 
-elif args.task == 'start-scala':
 
+def start_scala():
     os.environ['SPARK_HOME'] = version
 
     if os.getenv('PATH') is None:
@@ -145,17 +144,84 @@ elif args.task == 'start-scala':
     os.environ['MASTER'] = f.readline().replace('\n','')
     os.system(version + '/bin/spark-shell')
 
-elif args.task == 'submit':
 
+def submit(master = ''):
     os.environ['SPARK_HOME'] = version
 
     if os.getenv('PATH') is None:
         os.environ['PATH'] = ""
 
     os.environ['PATH'] = os.environ['PATH'] + ":" + "/usr/local/python-2.7.6/bin"
-    f = open(os.path.expanduser("~") + '/spark-master', 'r')
-    master = f.readline().replace('\n','')
+    if master == '':
+        with open(os.path.expanduser("~") + '/spark-master', 'r') as f:
+            master = f.readline().replace('\n','')
     os.environ['MASTER'] = master
     os.system(version + '/bin/spark-submit --master ' + master + ' ' + args.submitargs)
+    
+
+parser = argparse.ArgumentParser(description="launch and manage spark cluster jobs")
+
+choices = ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'launch-submit-and-destroy')
+
+parser.add_argument("task", choices=choices)
+parser.add_argument("-n", "--nnodes", type=int, default=2, required=False)
+parser.add_argument("-i", "--ipython", action="store_true")
+parser.add_argument("-v", "--version", choices=("1", "2", "3"), default="1", required=False)
+parser.add_argument("-j", "--jobid", type=int, default=None, required=False)
+parser.add_argument("-s", "--submitargs", type=str, default='', required=False)
+
+args = parser.parse_args()
+
+SPARKVERSIONS = {
+    '1': '/usr/local/spark-current',
+    '2': '/usr/local/spark-master',
+    '3': '/usr/local/spark-test'
+}
+
+SPARKVERSIONSSHORT = {
+    '1': 'spark',
+    '2': 'spark2',
+    '3': 'spark3'
+}
+
+version = SPARKVERSIONS[args.version]
+version_short = SPARKVERSIONSSHORT[args.version]
+
+if args.nnodes == 1:
+    raise Exception('Cannot start a Spark cluster with only 1 node, please request 2 or more.')
+
+if args.task == 'launch':
+    launch()
+
+elif args.task == 'login':
+    login()
+
+elif args.task == 'destroy':
+    destroy()
+
+
+elif args.task == 'start':
+    start()
+    
+
+elif args.task == 'start-scala':
+    start_scala()
+    
+
+elif args.task == 'submit':
+    submit()
+    
+
+elif args.task == 'launch-submit-and-destroy':
+    jobId  = launch()
+    master = ''
+    while( master == '' ):
+        master = findMasterByJobId(jobId)
+    master = 'spark://%s:7077' % master
+    print jobId, master
+    submit(master)
+    destroy(jobId)
+
+
 
 

--- a/spark-janelia
+++ b/spark-janelia
@@ -41,7 +41,7 @@ def launch():
     return jobId
 
 
-def login(jobId = ''):
+def login():
     status = subprocess.check_output(["qstat", "-xml"])
     qtree = ET.fromstring(status)[0]
     jtree = ET.fromstring(status)[1]

--- a/spark-janelia
+++ b/spark-janelia
@@ -132,7 +132,7 @@ def start():
     os.system(version + '/bin/pyspark')
 
 
-def start_scala():
+def startScala():
     os.environ['SPARK_HOME'] = version
 
     if os.getenv('PATH') is None:
@@ -211,7 +211,7 @@ if __name__ == "__main__":
                         
                         
     elif args.task == 'start-scala':
-        start_scala()   
+        startScala()   
                         
                         
     elif args.task == 'submit':

--- a/spark-janelia
+++ b/spark-janelia
@@ -74,14 +74,11 @@ def login():
             print('\n')
 
 
-def destroy(jobId = ''):
+def destroy(jobId ):
     status = subprocess.check_output(["qstat", "-xml"])
     qtree = ET.fromstring(status)[0]
     jtree = ET.fromstring(status)[1]
     jobs = qtree.findall('job_list')
-    jid = args.jobid or jobId
-    if jid:
-        jid = int(jid)
     if len(jobs) == 0:
         print('\n')
         print >> sys.stderr, "No running jobs found"
@@ -93,10 +90,9 @@ def destroy(jobId = ''):
             state = job.find('state').text
             jobid = job.find('JB_job_number').text
             if (jobclass == version_short + ".default") and (state == 'r'):
-                if jid:
-                    if int(jobid) == jid:
-                        output = subprocess.check_output(['qdel', jobid])
-                        deleted += 1
+                if jobId and jobid == jobId:
+                    output = subprocess.check_output(['qdel', jobid])
+                    deleted += 1
                 else:
                     output = subprocess.check_output(['qdel', jobid])
                     deleted += 1
@@ -198,7 +194,7 @@ elif args.task == 'login':
     login()
 
 elif args.task == 'destroy':
-    destroy()
+    destroy(args.jobid or '')
 
 
 elif args.task == 'start':

--- a/spark-janelia
+++ b/spark-janelia
@@ -6,6 +6,7 @@ import sys
 import argparse
 import subprocess
 import xml.etree.ElementTree as ET
+import time
 
 
 def findMasterByJobId(jobId):
@@ -214,6 +215,7 @@ elif args.task == 'lsd':
     master = ''
     while( master == '' ):
         master = findMasterByJobId(jobId)
+        time.sleep(1) # wait 1 second to avoid spamming the cluster
     master = 'spark://%s:7077' % master
     print('\n')
     print('%-20s%s\n%-20s%s' % ( 'job id:', jobId, 'spark master:', master ) )

--- a/spark-janelia
+++ b/spark-janelia
@@ -162,7 +162,7 @@ def submit(master = ''):
 
 parser = argparse.ArgumentParser(description="launch and manage spark cluster jobs")
 
-choices = ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'launch-submit-and-destroy')
+choices = ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'lsd')
 
 parser.add_argument("task", choices=choices)
 parser.add_argument("-n", "--nnodes", type=int, default=2, required=False)
@@ -213,7 +213,7 @@ elif args.task == 'submit':
     submit()
     
 
-elif args.task == 'launch-submit-and-destroy':
+elif args.task == 'lsd':
     jobId  = launch()
     master = ''
     while( master == '' ):

--- a/spark-janelia
+++ b/spark-janelia
@@ -80,7 +80,8 @@ def destroy(jobId = ''):
     jtree = ET.fromstring(status)[1]
     jobs = qtree.findall('job_list')
     jid = args.jobid or jobId
-    jid = int(jid)
+    if jid:
+        jid = int(jid)
     if len(jobs) == 0:
         print('\n')
         print >> sys.stderr, "No running jobs found"

--- a/spark-janelia
+++ b/spark-janelia
@@ -215,7 +215,9 @@ elif args.task == 'lsd':
     while( master == '' ):
         master = findMasterByJobId(jobId)
     master = 'spark://%s:7077' % master
-    print jobId, master
+    print('\n')
+    print('%-20s%s\n%-20s%s' % ( 'job id:', jobId, 'spark master:', master ) )
+    print('\n')
     submit(master)
     destroy(jobId)
 

--- a/spark-janelia
+++ b/spark-janelia
@@ -7,6 +7,7 @@ import argparse
 import subprocess
 import xml.etree.ElementTree as ET
 import time
+import multiprocessing
 
 
 def findMasterByJobId(jobId):
@@ -155,73 +156,80 @@ def submit(master = ''):
             master = f.readline().replace('\n','')
     os.environ['MASTER'] = master
     os.system(version + '/bin/spark-submit --master ' + master + ' ' + args.submitargs)
-    
-
-parser = argparse.ArgumentParser(description="launch and manage spark cluster jobs")
-
-choices = ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'lsd')
-
-parser.add_argument("task", choices=choices)
-parser.add_argument("-n", "--nnodes", type=int, default=2, required=False)
-parser.add_argument("-i", "--ipython", action="store_true")
-parser.add_argument("-v", "--version", choices=("1", "2", "3"), default="1", required=False)
-parser.add_argument("-j", "--jobid", type=int, default=None, required=False)
-parser.add_argument("-s", "--submitargs", type=str, default='', required=False)
-
-args = parser.parse_args()
-
-SPARKVERSIONS = {
-    '1': '/usr/local/spark-current',
-    '2': '/usr/local/spark-master',
-    '3': '/usr/local/spark-test'
-}
-
-SPARKVERSIONSSHORT = {
-    '1': 'spark',
-    '2': 'spark2',
-    '3': 'spark3'
-}
-
-version = SPARKVERSIONS[args.version]
-version_short = SPARKVERSIONSSHORT[args.version]
-
-if args.nnodes == 1:
-    raise Exception('Cannot start a Spark cluster with only 1 node, please request 2 or more.')
-
-if args.task == 'launch':
-    launch()
-
-elif args.task == 'login':
-    login()
-
-elif args.task == 'destroy':
-    destroy(args.jobid or '')
 
 
-elif args.task == 'start':
-    start()
-    
-
-elif args.task == 'start-scala':
-    start_scala()
-    
-
-elif args.task == 'submit':
-    submit()
-    
-
-elif args.task == 'lsd':
-    jobId  = launch()
-    master = ''
-    while( master == '' ):
-        master = findMasterByJobId(jobId)
-        time.sleep(1) # wait 1 second to avoid spamming the cluster
-    master = 'spark://%s:7077' % master
-    print('\n')
-    print('%-20s%s\n%-20s%s' % ( 'job id:', jobId, 'spark master:', master ) )
-    print('\n')
+def submitAndDestroy( master, jobId ):
     submit(master)
     destroy(jobId)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="launch and manage spark cluster jobs")
+                        
+    choices = ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'lsd')
+                        
+    parser.add_argument("task", choices=choices)
+    parser.add_argument("-n", "--nnodes", type=int, default=2, required=False)
+    parser.add_argument("-i", "--ipython", action="store_true")
+    parser.add_argument("-v", "--version", choices=("1", "2", "3"), default="1", required=False)
+    parser.add_argument("-j", "--jobid", type=int, default=None, required=False)
+    parser.add_argument("-t", "--sleep_time", type=int, default=86400, required=False)
+    parser.add_argument("-s", "--submitargs", type=str, default='', required=False)
+                        
+    args = parser.parse_args()
+                        
+    SPARKVERSIONS = {   
+        '1': '/usr/local/spark-current',
+        '2': '/usr/local/spark-master',
+        '3': '/usr/local/spark-test'
+    }                   
+                        
+    SPARKVERSIONSSHORT = {
+        '1': 'spark',   
+        '2': 'spark2',  
+        '3': 'spark3'   
+    }                   
+                        
+    version = SPARKVERSIONS[args.version]
+    version_short = SPARKVERSIONSSHORT[args.version]
+                        
+    if args.nnodes == 1:
+        raise Exception('Cannot start a Spark cluster with only 1 node, please request 2 or more.')
+                        
+    if args.task == 'launch':
+        launch(str(args.sleep_time))
+                        
+    elif args.task == 'login':
+        login()         
+                        
+    elif args.task == 'destroy':
+        destroy(args.jobid or '')
+                        
+                        
+    elif args.task == 'start':
+        start()         
+                        
+                        
+    elif args.task == 'start-scala':
+        start_scala()   
+                        
+                        
+    elif args.task == 'submit':
+        submit()        
+                        
+                        
+    elif args.task == 'lsd':
+        jobId  = launch(str(args.sleep_time))
+        master = ''     
+        while( master == '' ):
+            master = findMasterByJobId(jobId)
+            time.sleep(1) # wait 1 second to avoid spamming the cluster
+        master = 'spark://%s:7077' % master
+        print('\n')     
+        print('%-20s%s\n%-20s%s' % ( 'job id:', jobId, 'spark master:', master ) )
+        print('\n')     
+        p = multiprocessing.Process(target=submitAndDestroy, args=(master, jobId))
+        p.start()       
 
 
 


### PR DESCRIPTION
Running `./spark-janelia <args> lsd -s <spark args>` launches a spark master, submits a task and deletes the job after completion.
In order to reuse existing code, I wrapped it inside functions and slightly modified them, whenever it was necessary.
I have tested each of the choices ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'lsd') and all worked for me.
