### PR TITLE
launch-in

### DIFF
--- a/spark-janelia
+++ b/spark-janelia
@@ -166,7 +166,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="launch and manage spark cluster jobs")
                         
-    choices = ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'lsd')
+    choices = ('launch', 'login', 'destroy', 'start', 'start-scala', 'submit', 'lsd', 'launch-in')
                         
     parser.add_argument("task", choices=choices)
     parser.add_argument("-n", "--nnodes", type=int, default=2, required=False)
@@ -205,18 +205,14 @@ if __name__ == "__main__":
     elif args.task == 'destroy':
         destroy(args.jobid or '')
                         
-                        
     elif args.task == 'start':
         start()         
-                        
                         
     elif args.task == 'start-scala':
         startScala()   
                         
-                        
     elif args.task == 'submit':
         submit()        
-                        
                         
     elif args.task == 'lsd':
         jobId  = launch(str(args.sleep_time))
@@ -231,6 +227,15 @@ if __name__ == "__main__":
         p = multiprocessing.Process(target=submitAndDestroy, args=(master, jobId))
         p.start()       
 
-
+    elif args.task == 'launch-in':
+        jobId = launch(str(args.sleep_time))
+        master = ''
+        while master == '':
+            master = findMasterByJobId(jobId)
+            time.sleep(1)
+            sys.stdout.write('.')
+            sys.stdout.flush()
+        print '\n\nspark master: {}\n'.format(master)
+        login()
 
 

--- a/spark-janelia
+++ b/spark-janelia
@@ -42,7 +42,6 @@ def launch(sleepTime='86400'):
     jobId = output.split(' ')[2]
     return jobId
 
-
 def login():
     status = subprocess.check_output(["qstat", "-xml"])
     qtree = ET.fromstring(status)[0]
@@ -158,6 +157,17 @@ def submit(master = ''):
     os.system(version + '/bin/spark-submit --master ' + master + ' ' + args.submitargs)
 
 
+def launchAndWait():
+        jobId  = launch(str(args.sleep_time))
+        master = ''     
+        while( master == '' ):
+            master = findMasterByJobId(jobId)
+            time.sleep(1) # wait 1 second to avoid spamming the cluster
+            sys.stdout.write('.')
+            sys.stdout.flush()
+        return master
+
+
 def submitAndDestroy( master, jobId ):
     submit(master)
     destroy(jobId)
@@ -215,11 +225,7 @@ if __name__ == "__main__":
         submit()        
                         
     elif args.task == 'lsd':
-        jobId  = launch(str(args.sleep_time))
-        master = ''     
-        while( master == '' ):
-            master = findMasterByJobId(jobId)
-            time.sleep(1) # wait 1 second to avoid spamming the cluster
+        master = launchAndWait()
         master = 'spark://%s:7077' % master
         print('\n')     
         print('%-20s%s\n%-20s%s' % ( 'job id:', jobId, 'spark master:', master ) )
@@ -228,13 +234,7 @@ if __name__ == "__main__":
         p.start()       
 
     elif args.task == 'launch-in':
-        jobId = launch(str(args.sleep_time))
-        master = ''
-        while master == '':
-            master = findMasterByJobId(jobId)
-            time.sleep(1)
-            sys.stdout.write('.')
-            sys.stdout.flush()
+        master = launchAndWait()
         print '\n\nspark master: {}\n'.format(master)
         login()
 


### PR DESCRIPTION
1. Added a new task, `launch-in`, that automates the process of: starting a spark job, waiting for the master to be specified, and logging in to the master.
2. Refactored the code, putting the "launch and wait" functionality into a helper function (audaciously named `launchAndWait`), since the `lsd` task also makes use of this functionality
3. Added a completely superfluous feature where, while waiting, one `.` is written to stdout each second to mark the passage of time, thus guiding the user to reflect on his/her mortality while he/she waits for the cluster....any second now. 
