### PR TITLE
added check for jclass == None

### DIFF
--- a/spark-janelia
+++ b/spark-janelia
@@ -58,7 +58,7 @@ def login():
             jclass = job.find('jclass_name').text
             state = job.find('state').text
             jobid = int(job.find('JB_job_number').text)
-            if (jclass[:5] == 'spark') and (state == 'r'):
+            if jclass and (jclass[:5] == 'spark') and (state == 'r'):
                 if args.jobid:
                     if jobid == args.jobid:
                         address = job.find('queue_name').text.split('@')[1]


### PR DESCRIPTION
If there's a `qlogin` job running, the `jclass` will be `None` and thus indexing `jclass` will return an error. Adding `if jclass and ...` to the conditional before indexing `jclass` short-circuits if `jclass == None` and thus prevents the error. I'm not sure if this is the best way to do this -- maybe I should wrap things in big `if jclass:` statement?